### PR TITLE
file: プロトコルバグの修正

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 node_modules/
 .vscode/
+docs/

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,10 @@
+# npm
 node_modules/
+semantic/
+semantic.json
+
+# エディタ
 .vscode/
+
+# ドキュメントリポジトリ
 docs/

--- a/main.js
+++ b/main.js
@@ -7,6 +7,7 @@ const fs = require('fs')
 
 // const
 const dirname = '__dirname'
+const PATH_DATA = JSON.parse(fs.readFileSync('./screen_info.json', 'utf-8'))
 
 // global
 let win
@@ -32,7 +33,7 @@ function createWindow(){
   })
 
   win.loadURL(url.format({
-    pathname: '/__dirname/splash_screen/index.html',
+    pathname: __dirname + PATH_DATA.splash_path,
     protocol: 'file:',
     slashes: true,
   }))
@@ -56,34 +57,32 @@ app.on('activate', () => {
   }
 })
 
-const PATH_DATA = JSON.parse(fs.readFileSync('./screen_info.json', 'utf-8'))
-
 ipcMain.on(PATH_DATA.event, (event, req) => {
   switch(req){
     case PATH_DATA.edit_path:
       win.loadURL(url.format({
-        pathname: PATH_DATA.edit_path,
+        pathname: __dirname + PATH_DATA.edit_path,
         protocol: 'file:',
         slashes: true,
       }))
       break
     case PATH_DATA.main_path:
       win.loadURL(url.format({
-        pathname: PATH_DATA.main_path,
+        pathname: __dirname + PATH_DATA.main_path,
         protocol: 'file:',
         slashes: true,
       }))
       break
     case PATH_DATA.pdf_path:
       win.loadURL(url.format({
-        pathname: PATH_DATA.pdf_path,
+        pathname: __dirname + PATH_DATA.pdf_path,
         protocol: 'file:',
         slashes: true,
       }))
       break
     case PATH_DATA.settings_path:
       win.loadURL(url.format({
-        pathname: PATH_DATA.settings_path,
+        pathname: __dirname + PATH_DATA.settings_path,
         protocol: 'file:',
         slashes: true,
     }))

--- a/main.js
+++ b/main.js
@@ -1,87 +1,92 @@
 'use strict'
-
+// require
 const { app, BrowserWindow, protocol, ipcMain } = require('electron')
 const path = require('path')
 const url = require('url')
 const fs = require('fs')
 
+// const
+const dirname = '__dirname'
+
+// global
 let win
 
 app.on('ready', () => {
-    protocol.interceptFileProtocol('file', (req, callback) => {
-        const requestedUrl = req.url.substr(7)
+  protocol.interceptFileProtocol('file', (req, callback) => {
+    let requrl = req.url.substr(7)
 
-        if (path.isAbsolute(requestedUrl)) {
-            callback(path.normalize(path.join(__dirname, requestedUrl)))
-        } else {
-            callback(requestedUrl)
-        }
-    })
+    // ルート以下の1番目を抽出
+    if(requrl.split('/')[1] === dirname) {
+      // __dirnameをパース
+      requrl = requrl.replace(/__dirname/, __dirname)
+    }
+    callback(requrl)
+  })
 })
 
 function createWindow(){
-    win = new BrowserWindow({
-        'width': 1200,
-        'height': 800,
-        'icon': './resource/img/icon.png',
-    })
+  win = new BrowserWindow({
+    'width': 1200,
+    'height': 800,
+    'icon': './resource/img/icon.png',
+  })
 
-    win.loadURL(url.format({
-        pathname: '/splash_screen/index.html',
-        protocol: 'file:',
-        slashes: true,
-    }))
+  win.loadURL(url.format({
+    pathname: '/__dirname/splash_screen/index.html',
+    protocol: 'file:',
+    slashes: true,
+  }))
 
-    win.on('closed', () => {
-        win = null
-    })
+  win.on('closed', () => {
+    win = null
+  })
 }
 
 app.on('ready', createWindow)
 
 app.on('window-all-closed', () => {
-    if(process.platform !== 'darwin'){
-        app.quit()
-    }
+  if(process.platform !== 'darwin'){
+    app.quit()
+  }
 })
 
 app.on('activate', () => {
-    if(win === null){
-        createWindow()
-    }
+  if(win === null){
+    createWindow()
+  }
 })
 
 const PATH_DATA = JSON.parse(fs.readFileSync('./screen_info.json', 'utf-8'))
 
 ipcMain.on(PATH_DATA.event, (event, req) => {
-    switch(req){
-        case PATH_DATA.edit_path:
-            win.loadURL(url.format({
-                pathname: PATH_DATA.edit_path,
-                protocol: 'file:',
-                slashes: true,
-            }))
-            break
-        case PATH_DATA.main_path:
-            win.loadURL(url.format({
-                pathname: PATH_DATA.main_path,
-                protocol: 'file:',
-                slashes: true,
-            }))
-            break
-        case PATH_DATA.pdf_path:
-            win.loadURL(url.format({
-                pathname: PATH_DATA.pdf_path,
-                protocol: 'file:',
-                slashes: true,
-            }))
-            break
-        case PATH_DATA.settings_path:
-            win.loadURL(url.format({
-                pathname: PATH_DATA.settings_path,
-                protocol: 'file:',
-                slashes: true,
-            }))
-            break
-    }
+  switch(req){
+    case PATH_DATA.edit_path:
+      win.loadURL(url.format({
+        pathname: PATH_DATA.edit_path,
+        protocol: 'file:',
+        slashes: true,
+      }))
+      break
+    case PATH_DATA.main_path:
+      win.loadURL(url.format({
+        pathname: PATH_DATA.main_path,
+        protocol: 'file:',
+        slashes: true,
+      }))
+      break
+    case PATH_DATA.pdf_path:
+      win.loadURL(url.format({
+        pathname: PATH_DATA.pdf_path,
+        protocol: 'file:',
+        slashes: true,
+      }))
+      break
+    case PATH_DATA.settings_path:
+      win.loadURL(url.format({
+        pathname: PATH_DATA.settings_path,
+        protocol: 'file:',
+        slashes: true,
+    }))
+    break
+  }
 })

--- a/main_screen/main.html
+++ b/main_screen/main.html
@@ -8,11 +8,11 @@
                 padding-top:15%;
         }
         </style>
-        <!-- semantic.css semantic.js common.js 読み込み --> 
-        <link rel="stylesheet" href="/node_modules/semantic-ui/dist/semantic.min.css" />
-        <script type="text/javascript" src="/require.js"></script>
-        <script type="text/javascript" src="/common.js"></script>
-        <script src="/node_modules/semantic-ui/dist/semantic.min.js"></script>
+        <!-- semantic.css semantic.js common.js 読み込み -->
+        <link rel="stylesheet" href="/__dirname/node_modules/semantic-ui/dist/semantic.min.css" />
+        <script type="text/javascript" src="/__dirname/require.js"></script>
+        <script type="text/javascript" src="/__dirname/common.js"></script>
+        <script src="/__dirname/node_modules/semantic-ui/dist/semantic.min.js"></script>
     </head>
     <body>
         <!-- サイドバーメニュー -->
@@ -54,11 +54,11 @@
         <!-- コンテンツ本体 -->
         <div class="pusher">
             <div align="center">
-                <img src="/resource/img/icon.svg" alt="アイコン">
+                <img src="/__dirname/resource/img/icon.svg" alt="アイコン">
             </div>
         </div>
 
         <!--main_screenの画面遷移-->
-        <script type="text/javascript" src="/main_screen/main_motion.js"></script>
+        <script type="text/javascript" src="/__dirname/main_screen/main_motion.js"></script>
     </body>
 </html>

--- a/package.json
+++ b/package.json
@@ -14,7 +14,6 @@
     },
     "dependencies": {
         "electron": "^1.6.2",
-        "fs": "0.0.1-security",
         "jquery": "^3.2.0",
         "semantic-ui": "^2.2.9"
     }

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
     "description": "",
     "main": "main.js",
     "scripts": {
-        "start": "electron main.js",
+        "start": "electron .",
         "test": "echo \"Error: no test specified\" && exit 1"
     },
     "keywords": [],

--- a/pdf_screen/pdf_export.html
+++ b/pdf_screen/pdf_export.html
@@ -8,11 +8,11 @@
             padding-top: 100px
         }
         </style>
-        <!-- semantic.css semantic.js common.js 読み込み --> 
-        <link rel="stylesheet" href="/node_modules/semantic-ui/dist/semantic.min.css">
-        <script type="text/javascript" src="/require.js"></script>
-        <script type="text/javascript" src="/common.js"></script>
-        <script src="/node_modules/semantic-ui/dist/semantic.min.js"></script>
+        <!-- semantic.css semantic.js common.js 読み込み -->
+        <link rel="stylesheet" href="/__dirname/node_modules/semantic-ui/dist/semantic.min.css">
+        <script type="text/javascript" src="/__dirname/require.js"></script>
+        <script type="text/javascript" src="/__dirname/common.js"></script>
+        <script src="/__dirname/node_modules/semantic-ui/dist/semantic.min.js"></script>
     </head>
     <body>
         <!-- サイドバー -->
@@ -71,6 +71,6 @@
         </div>
 
         <!--pdf_screenの画面遷移-->
-        <script type="text/javascript" src="/pdf_screen/pdf_motion.js"></script>
+        <script type="text/javascript" src="/__dirname/pdf_screen/pdf_motion.js"></script>
     </body>
 </html>

--- a/screen_info.json
+++ b/screen_info.json
@@ -1,4 +1,5 @@
 {
+    "splash_path": "/splash_screen/index.html",
     "edit_path": "/edit_screen/edit.html",
     "main_path": "/main_screen/main.html",
     "pdf_path": "/pdf_screen/pdf_export.html",

--- a/splash_screen/index.html
+++ b/splash_screen/index.html
@@ -3,8 +3,8 @@
     <head>
         <meta charset="UTF-8">
         <title>coordinote</title>
-        <link href="splash.css" rel="stylesheet">
-        <meta http-equiv="refresh" content="5; url=/main_screen/main.html">
+        <link href="/__dirname/splash_screen/splash.css" rel="stylesheet">
+        <meta http-equiv="refresh" content="5; url=/__dirname/main_screen/main.html">
 
         <style>
         img{
@@ -14,7 +14,7 @@
     </head>
     <body>
         <div align="center">
-        <img src="/resource/img/logo.svg" alt="ロゴ">
+        <img src="/__dirname/resource/img/logo.svg" alt="ロゴ">
         </div>
     </body>
 </html>

--- a/splash_screen/index.html
+++ b/splash_screen/index.html
@@ -1,10 +1,11 @@
-<!DOCTYPE>
+<!DOCTYPE html>
 <html>
     <head>
-        <meta charset="UTF-8">
+        <meta charset="utf-8">
         <title>coordinote</title>
+        <script src="/__dirname/require.js"></script>
+        <script src="/__dirname/common.js"></script>
         <link href="/__dirname/splash_screen/splash.css" rel="stylesheet">
-        <meta http-equiv="refresh" content="5; url=/__dirname/main_screen/main.html">
 
         <style>
         img{
@@ -16,5 +17,10 @@
         <div align="center">
         <img src="/__dirname/resource/img/logo.svg" alt="ロゴ">
         </div>
+
+        <!-- TODO: metaの処理をJSで再記述(ipcRendererを使用のこと) -->
+        <script>
+          ipcRenderer.send(PATH_DATA.event, PATH_DATA.main_path)
+        </script>
     </body>
 </html>


### PR DESCRIPTION
* フロントエンドからのリクエストハンドラのパース方法を変更
  - old
    - `/path/to/file`
  - new
    - `/__dirname/path/to/file`
* バックエンドからのリクエストハンドラ(htmlファイルに限る)のパースを停止
  - old
    - `'/path/to/file.html'`
  - new
    - `__dirname + '/path/to/file.html'`
* 現在記述されているurlの記述方式を変更
* `.gitignore`に追記
  - `docs/`
* `main.js`におけるインデント幅の変更
  - old
    - 4
  - new
    - 2