### PR TITLE
clips or tiles(cid指定)におけるtag全検索(重複なし)の追加

### DIFF
--- a/database/clip_schema.js
+++ b/database/clip_schema.js
@@ -1,3 +1,5 @@
+'use strict'
+
 // require
 const async = require('async')
 const validate = require('jsonschema').validate

--- a/database/nedb_module.js
+++ b/database/nedb_module.js
@@ -44,6 +44,7 @@ DBMethod.prototype.get_clips_tags = function(callback_arg){
       })
     },
     (tagConcat, callback) => {
+      // remove duplication
       let tagSet = new Set(tagConcat)
       callback(null, tagSet)
     },
@@ -83,6 +84,7 @@ DBMethod.prototype.get_tiles_cid_tags = function(clip_id, callback_arg){
       })
     },
     (tagConcat, callback) => {
+      // remove duplication
       let tagSet = new Set(tagConcat)
       callback(null, tagSet)
     },

--- a/database/test/nedb_test.js
+++ b/database/test/nedb_test.js
@@ -8,6 +8,18 @@ let dbmethod = new NeDB_Modules()
 let target_cid = "aW2hG7kwoOPfhzkX"
 
 /*
+dbmethod.get_tiles_cid_tags(target_cid, (tags) => {
+  console.log(tags)
+})
+//*/
+
+/*
+dbmethod.get_clips_tags((tags) => {
+  console.log(tags)
+})
+//*/
+
+/*
 let instance = {
   "cid": target_cid,
   "idx": 0,

--- a/database/tile_schema.js
+++ b/database/tile_schema.js
@@ -1,3 +1,5 @@
+'use strict'
+
 // require
 const async = require('async')
 const validate = require('jsonschema').validate


### PR DESCRIPTION
以下の要件を実装

* clips `tag` 要素全検索
  - 条件
    - 重複なし
    - `Array` 型
    - callbackの引数にて返す
* tiles `tag` 要素全検索
  - 条件
    - 重複なし
    - clip_idの指定が必要
    - `Array` 型
    - callbackの引数にて返す