### PR TITLE
add tag検索の絞り込み

### DIFF
--- a/database/test/nedb_test.js
+++ b/database/test/nedb_test.js
@@ -8,13 +8,25 @@ let dbmethod = new NeDB_Modules()
 let target_cid = "aW2hG7kwoOPfhzkX"
 
 /*
-dbmethod.get_tiles_cid_tags(target_cid, (tags) => {
+dbmethod.get_tiles_cidtags(target_cid, ['よくわからなかった'], (clips) => {
+  console.log(clips)
+})
+//*/
+
+/*
+dbmethod.get_clips_tags(['helloworld', 'test'], (clips) => {
+  console.log(clips)
+})
+//*/
+
+/*
+dbmethod.get_alltilestags_cid(target_cid, (tags) => {
   console.log(tags)
 })
 //*/
 
 /*
-dbmethod.get_clips_tags((tags) => {
+dbmethod.get_allclipstags((tags) => {
   console.log(tags)
 })
 //*/
@@ -40,6 +52,12 @@ dbmethod.set_tile(instance, (newdocs) => {
    console.log(docs)
    })
    //*/
+
+/*
+dbmethod.get_clip_id(target_cid, (doc) => {
+  console.log(doc)
+})
+//*/
 
 /*
    dbmethod.set_clip(['helloworld', 'coordinote'], (newdocs) => {


### PR DESCRIPTION
* クエリメソッドの命名規則変更
  - `処理`_`得るデータ`_`条件`()
* 以下のクエリを記述
  - `tag` の検索条件に合致する `clip` をすべて返す
  - `tag` の検索条件に合致する `tile` をすべて返す