### PR TITLE
fix tileが追加されないバグ, メソッド名, 関数化

### DIFF
--- a/nedb_module/nedb_module.js
+++ b/nedb_module/nedb_module.js
@@ -19,6 +19,7 @@ let DBMethod = function(){
 }
 
 // loader
+/* load tile database instance fron cid */
 DBMethod.prototype.dbLoad = function(cid, callback){
   this.db.clips.findOne({_id: cid}, (err, doc) => {
     if(err){
@@ -34,6 +35,7 @@ DBMethod.prototype.dbLoad = function(cid, callback){
 }
 
 // find
+/* find clip by _id */
 DBMethod.prototype.find_clip_id = function(id, callback){
   this.db.clips.findOne({_id: id}, (err, doc) => {
     if(this.db[doc.tile_file] === undefined){
@@ -46,6 +48,7 @@ DBMethod.prototype.find_clip_id = function(id, callback){
   })
 }
 
+/* find all type of tag in clips */
 DBMethod.prototype.find_allclipstags = function(callback_arg){
   async.waterfall([
     (callback) => {
@@ -73,6 +76,7 @@ DBMethod.prototype.find_allclipstags = function(callback_arg){
   ])
 }
 
+/* find clips by selected tags(about clip) */
 DBMethod.prototype.find_clips_tags = function(clip_tags, callback_arg){
   async.waterfall([
     (callback) => {
@@ -102,6 +106,7 @@ DBMethod.prototype.find_clips_tags = function(clip_tags, callback_arg){
   ])
 }
 
+/* find tiles by cid */
 DBMethod.prototype.find_tiles_cid = function(clip_id, callback){
   this.dbLoad(clip_id, (tile_file) => {
     this.db[tile_file].find({cid: clip_id}, (err, tiledocs) => {
@@ -113,6 +118,7 @@ DBMethod.prototype.find_tiles_cid = function(clip_id, callback){
   })
 }
 
+/* find all type of tag in tiles by cid */
 DBMethod.prototype.find_alltilestags_cid = function(clip_id, callback_arg){
   async.waterfall([
     (callback) => {
@@ -142,6 +148,7 @@ DBMethod.prototype.find_alltilestags_cid = function(clip_id, callback_arg){
   ])
 }
 
+/* find tiles from selected tags(about tile) */
 DBMethod.prototype.find_tiles_cidtags = function(clip_id, tile_tags, callback_arg){
   async.waterfall([
     (callback) => {
@@ -150,7 +157,8 @@ DBMethod.prototype.find_tiles_cidtags = function(clip_id, tile_tags, callback_ar
       async.each(tile_tags, (tile_tag, callback) => {
         tile_tags_edited.push({tag: tile_tag})
         callback()
-      },(err) => {
+      },
+      (err) => {
         callback(null, tile_tags_edited)
       })
     },
@@ -172,6 +180,7 @@ DBMethod.prototype.find_tiles_cidtags = function(clip_id, tile_tags, callback_ar
 
 
 // insert
+/* insert clip by tag */
 DBMethod.prototype.insert_clip = function(tag, callback_arg){
   async.waterfall([
     (callback) => {
@@ -215,6 +224,7 @@ DBMethod.prototype.insert_clip = function(tag, callback_arg){
   ])
 }
 
+/* insert clip by document(shemed) */
 DBMethod.prototype.insert_tile = function(instance, callback){
   tile_schema.tile_valid(instance, (result) => {
     if(result.valid){
@@ -233,6 +243,7 @@ DBMethod.prototype.insert_tile = function(instance, callback){
 }
 
 // update
+/* update tag about clip by _id */
 DBMethod.prototype.update_cliptags_id = function(tags, clip_id, callback){
   clip_schema.tag_valid(tags, (result) => {
     if(result.valid){
@@ -247,6 +258,7 @@ DBMethod.prototype.update_cliptags_id = function(tags, clip_id, callback){
   })
 }
 
+/* update idx about tile by cid and _id */
 DBMethod.prototype.update_tileidx_cidid = function(idx, clip_id, tile_id, callback){
   tile_schema.idx_valid(idx, (result) => {
     if(result.valid){
@@ -263,6 +275,7 @@ DBMethod.prototype.update_tileidx_cidid = function(idx, clip_id, tile_id, callba
   })
 }
 
+/* update col about tile by cid and _id */
 DBMethod.prototype.update_tilecol_cidid = function(col, clip_id, tile_id, callback){
   tile_schema.col_valid(col, (result) => {
     if(result.valid){
@@ -279,6 +292,7 @@ DBMethod.prototype.update_tilecol_cidid = function(col, clip_id, tile_id, callba
   })
 }
 
+/* update tag about tile by cid and _id */
 DBMethod.prototype.update_tiletags_cidid = function(tags, clip_id, tile_id, callback){
   tile_schema.tag_valid(tags, (result) => {
     if(result.valid){
@@ -295,6 +309,7 @@ DBMethod.prototype.update_tiletags_cidid = function(tags, clip_id, tile_id, call
   })
 }
 
+/* update con about tile by cid and _id */
 DBMethod.prototype.update_tilecon_cidid = function(con, clip_id, tile_id, callback){
   tile_schema.con_valid(con, (result) => {
     if(result.valid){
@@ -312,6 +327,7 @@ DBMethod.prototype.update_tilecon_cidid = function(con, clip_id, tile_id, callba
 }
 
 // delete
+/* delete clip by _id */
 DBMethod.prototype.delete_clip_id = function(clip_id, callback){
   // delete clip and tiles
   this.dbLoad(clip_id, (tile_file) => {
@@ -323,6 +339,7 @@ DBMethod.prototype.delete_clip_id = function(clip_id, callback){
   })
 }
 
+/* delete tile by cid and _id */
 DBMethod.prototype.delete_tile_cidid = function(clip_id, tile_id, callback){
   this.dbLoad(clip_id, (tile_file) => {
     this.db[tile_file].remove({_id: tile_id}, {}, (numRemoved) => {

--- a/nedb_module/nedb_module.js
+++ b/nedb_module/nedb_module.js
@@ -21,15 +21,20 @@ let DBMethod = function(){
 // loader
 DBMethod.prototype.dbLoad = function(cid, callback){
   this.db.clips.findOne({_id: cid}, (err, doc) => {
-    if(this.db[doc.tile_file] === undefined){
-      this.db[doc.tile_file] = new nedb({filename: DB_DIR + doc.tile_file + '.db', autoload: true})
+    if(err){
+      console.error(err)
+    }
+    else{
+      if(this.db[doc.tile_file] === undefined){
+        this.db[doc.tile_file] = new nedb({filename: DB_DIR + doc.tile_file + '.db', autoload: true})
+      }
       callback(doc.tile_file)
     }
   })
 }
 
-// get
-DBMethod.prototype.get_clip_id = function(id, callback){
+// find
+DBMethod.prototype.find_clip_id = function(id, callback){
   this.db.clips.findOne({_id: id}, (err, doc) => {
     if(this.db[doc.tile_file] === undefined){
       this.db[doc.tile_file] = new nedb({filename: DB_DIR + doc.tile_file + '.db', autoload: true})
@@ -41,71 +46,17 @@ DBMethod.prototype.get_clip_id = function(id, callback){
   })
 }
 
-DBMethod.prototype.get_allclipstags = function(callback_arg){
+DBMethod.prototype.find_allclipstags = function(callback_arg){
   async.waterfall([
     (callback) => {
       // projection by tag elem
       this.db.clips.find({}, {tag: 1}, (err, docs) => {
         let tagConcat = []
-        for(let doc of docs){
+        async.eachSeries(docs, (doc, callback) => {
           tagConcat = tagConcat.concat(doc.tag)
-        }
-        callback(null, tagConcat)
-      })
-    },
-    (tagConcat, callback) => {
-      // remove duplication
-      let tagSet = new Set(tagConcat)
-      callback(null, tagSet)
-    },
-    (tagSet, callback) => {
-      callback_arg(Array.from(tagSet.values()))
-      callback(null)
-    }
-  ])
-}
-
-DBMethod.prototype.get_clips_tags = function(clip_tags, callback_arg){
-  async.waterfall([
-    (callback) => {
-      for(let i = 0; i < clip_tags.length; i++){
-        clip_tags[i] = {tag: clip_tags[i]}
-      }
-      callback(null, clip_tags)
-    },
-    (clip_tags, callback) => {
-      this.db.clips.find({$and: clip_tags}, (err, docs) => {
-        callback_arg(docs)
-      })
-      callback(null)
-    }
-  ])
-}
-
-DBMethod.prototype.get_tiles_cid = function(clip_id, callback){
-  this.db.clips.findOne({_id: clip_id}, (err, doc) => {
-    if(this.db[doc.tile_file] === undefined){
-      this.db[doc.tile_file] = new nedb({filename: DB_DIR + doc.tile_file + '.db', autoload: true})
-    }
-    this.db[doc.tile_file].find({cid: doc._id}, (err, tiledocs) => {
-      callback(tiledocs)
-    })
-  })
-}
-
-DBMethod.prototype.get_alltilestags_cid = function(clip_id, callback_arg){
-  async.waterfall([
-    (callback) => {
-      this.db.clips.findOne({_id: clip_id}, (err, doc) => {
-        if(this.db[doc.tile_file] === undefined){
-          this.db[doc.tile_file] = new nedb({filename: DB_DIR + doc.tile_file + '.db', autoload: true})
-        }
-        // projection by tag elem
-        this.db[doc.tile_file].find({cid: doc._id}, {tag: 1}, (err, tiledocs) => {
-          let tagConcat = []
-          for(let doc of tiledocs){
-            tagConcat = tagConcat.concat(doc.tag)
-          }
+          callback()
+        },
+        (err) => {
           callback(null, tagConcat)
         })
       })
@@ -122,24 +73,96 @@ DBMethod.prototype.get_alltilestags_cid = function(clip_id, callback_arg){
   ])
 }
 
-DBMethod.prototype.get_tiles_cidtags = function(clip_id, tile_tags, callback_arg){
+DBMethod.prototype.find_clips_tags = function(clip_tags, callback_arg){
   async.waterfall([
     (callback) => {
-      for(let i = 0; i < tile_tags.length; i++){
-        tile_tags[i] = {tag: tile_tags[i]}
+      // convert to query from clips_tags
+      let clip_tags_edited = []
+      async.each(clip_tags, (clip_tag, callback) => {
+        clip_tags_edited.push({tag: clip_tag})
+        callback()
+      },(err) => {
+        callback(null, clip_tags_edited)
+      })
+    },
+    (clip_tags, callback) => {
+      this.db.clips.find({$and: clip_tags}, (err, clipdocs) => {
+        let clipdocs_edited = []
+        async.eachSeries(clipdocs, (doc, callback) => {
+          this.find_tiles_cid(doc._id, (tiledocs) => {
+            clipdocs_edited.push(Object.assign(doc, {tile: tiledocs}))
+            callback()
+          })
+        },
+        (err) => {
+          callback_arg(clipdocs_edited)
+        })
+      })
+    }
+  ])
+}
+
+DBMethod.prototype.find_tiles_cid = function(clip_id, callback){
+  this.dbLoad(clip_id, (tile_file) => {
+    this.db[tile_file].find({cid: clip_id}, (err, tiledocs) => {
+      if(err){
+        console.error(err)
       }
-      callback(null, tile_tags)
+      callback(tiledocs)
+    })
+  })
+}
+
+DBMethod.prototype.find_alltilestags_cid = function(clip_id, callback_arg){
+  async.waterfall([
+    (callback) => {
+      this.dbLoad(clip_id, (tile_file) => {
+        // projection by tag elem
+        this.db[tile_file].find({cid: clip_id}, {tag: 1}, (err, tiledocs) => {
+          let tagConcat = []
+          async.eachSeries(tiledocs, (doc, callback) => {
+            tagConcat = tagConcat.concat(doc.tag)
+            callback()
+          },
+          (err) => {
+            callback(null, tagConcat)
+          })
+        })
+      })
+    },
+    (tagConcat, callback) => {
+      // remove duplication
+      let tagSet = new Set(tagConcat)
+      callback(null, tagSet)
+    },
+    (tagSet, callback) => {
+      callback_arg(Array.from(tagSet.values()))
+      callback(null)
+    }
+  ])
+}
+
+DBMethod.prototype.find_tiles_cidtags = function(clip_id, tile_tags, callback_arg){
+  async.waterfall([
+    (callback) => {
+      // convert to query from tile_tags
+      let tile_tags_edited = []
+      async.each(tile_tags, (tile_tag, callback) => {
+        tile_tags_edited.push({tag: tile_tag})
+        callback()
+      },(err) => {
+        callback(null, tile_tags_edited)
+      })
     },
     (tile_tags, callback) => {
-      this.db.clips.findOne({_id: clip_id}, (err, doc) => {
-        if(this.db[doc.tile_file] === undefined){
-          this.db[doc.tile_file] = new nedb({filename: DB_DIR + doc.tile_file + '.db', autoload: true})
-        }
-        callback(null, tile_tags, doc.tile_file)
+      // clip load and fetch tile_file
+      this.dbLoad(clip_id, (tile_file) => {
+        callback(null, tile_tags, tile_file)
       })
     },
     (tile_tags, tile_file, callback) => {
-      this.db[tile_file].find({$and: tile_tags}, (err, docs) => {
+      // search tags and cid
+      this.db[tile_file].find({$and: tile_tags.concat({cid: clip_id})}, (err, docs) => {
         callback_arg(docs)
       })
       callback(null)
@@ -148,8 +171,8 @@ DBMethod.prototype.get_tiles_cidtags = function(clip_id, tile_tags, callback_arg
 }
 
 
-// set
-DBMethod.prototype.set_clip = function(tag, callback_arg){
+// insert
+DBMethod.prototype.insert_clip = function(tag, callback_arg){
   async.waterfall([
     (callback) => {
       // document instance
@@ -192,15 +215,12 @@ DBMethod.prototype.set_clip = function(tag, callback_arg){
   ])
 }
 
-DBMethod.prototype.set_tile = function(instance, callback){
+DBMethod.prototype.insert_tile = function(instance, callback){
   tile_schema.tile_valid(instance, (result) => {
     if(result.valid){
       // insert data(for {clip.tile_file}.db)
-      this.db.clips.findOne({_id: instance.cid}, (err, doc) => {
-        if(this.db[doc.tile_file] === undefined){
-          this.db[doc.tile_file] = new nedb({filename: DB_DIR + doc.tile_file + '.db', autoload: true})
-        }
-        this.db[doc.tile_file].insert(instance, (err, newdocs) => {
+      this.dbLoad(instance.cid, (tile_file) => {
+        this.db[tile_file].insert(instance, (err, newdocs) => {
           callback(newdocs)
         })
       })
@@ -296,7 +316,6 @@ DBMethod.prototype.delete_clip_id = function(clip_id, callback){
   // delete clip and tiles
   this.dbLoad(clip_id, (tile_file) => {
     this.db[tile_file].remove({cid: clip_id}, {multi: true}, (numRemoved) => {
-      console.log(numRemoved)
       this.db.clips.remove({_id: clip_id}, {}, () => {
         callback()
       })
@@ -307,7 +326,6 @@ DBMethod.prototype.delete_clip_id = function(clip_id, callback){
 DBMethod.prototype.delete_tile_cidid = function(clip_id, tile_id, callback){
   this.dbLoad(clip_id, (tile_file) => {
     this.db[tile_file].remove({_id: tile_id}, {}, (numRemoved) => {
-      console.log(numRemoved)
       callback()
     })
   })

--- a/nedb_module/nedb_module.js
+++ b/nedb_module/nedb_module.js
@@ -88,7 +88,7 @@ DBMethod.prototype.find_clips_tags = function(clip_tags, callback_arg){
     (clip_tags, callback) => {
       this.db.clips.find({$and: clip_tags}, (err, clipdocs) => {
         let clipdocs_edited = []
-        async.eachSeries(clipdocs, (doc, callback) => {
+        async.each(clipdocs, (doc, callback) => {
           this.find_tiles_cid(doc._id, (tiledocs) => {
             clipdocs_edited.push(Object.assign(doc, {tile: tiledocs}))
             callback()

--- a/nedb_module/nedb_module.js
+++ b/nedb_module/nedb_module.js
@@ -19,7 +19,7 @@ let DBMethod = function(){
 }
 
 // loader
-/* load tile database instance fron cid */
+/* load tile database instance by cid */
 DBMethod.prototype.dbLoad = function(cid, callback){
   this.db.clips.findOne({_id: cid}, (err, doc) => {
     if(err){

--- a/nedb_module/test/nedb_test.js
+++ b/nedb_module/test/nedb_test.js
@@ -8,21 +8,21 @@ let dbmethod = new NeDB_Modules()
 let target_cid = "aW2hG7kwoOPfhzkX"
 let target_id = "9SOzR0peDyDw9e80"
 
-//*
-dbmethod.delete_clip_id(target_cid, () => {
-  console.log('deleted')
-})
-//*/
+/*
+   dbmethod.delete_clip_id(target_cid, () => {
+   console.log('deleted')
+   })
+   //*/
 
 /*
-let idx = 5
-let col = 7
-let tags = ["test", "updated"]
-let con = "updated content"
-dbmethod.update_tilecon_cidid(con, target_cid, target_id, (doc) => {
-  console.log(doc)
-})
-//*/
+   let idx = 5
+   let col = 7
+   let tags = ["test", "updated"]
+   let con = "updated content"
+   dbmethod.update_tilecon_cidid(con, target_cid, target_id, (doc) => {
+   console.log(doc)
+   })
+   //*/
 
 /*
    dbmethod.update_cliptags_id(["test", "updated"], target_cid, (doc) => {
@@ -31,30 +31,31 @@ dbmethod.update_tilecon_cidid(con, target_cid, target_id, (doc) => {
    //*/
 
 /*
-   dbmethod.get_tiles_cidtags(target_cid, ['よくわからなかった'], (clips) => {
+   dbmethod.find_tiles_cidtags(target_cid, ['よくわからなかった'], (clips) => {
    console.log(clips)
    })
    //*/
 
 /*
-   dbmethod.get_clips_tags(['helloworld', 'test'], (clips) => {
+dbmethod.find_clips_tags(['helloworld'], (clips) => {
    console.log(clips)
    })
    //*/
 
 /*
-   dbmethod.get_alltilestags_cid(target_cid, (tags) => {
+   dbmethod.find_alltilestags_cid(target_cid, (tags) => {
    console.log(tags)
    })
    //*/
 
 /*
-   dbmethod.get_allclipstags((tags) => {
+   dbmethod.find_allclipstags((tags) => {
    console.log(tags)
    })
    //*/
 
 /*
+// validation error
    let instance = {
    "cid": target_cid,
    "idx": 0,
@@ -65,25 +66,25 @@ dbmethod.update_tilecon_cidid(con, target_cid, target_id, (doc) => {
    "hoge": "hoge"
    }
 
-   dbmethod.set_tile(instance, (newdocs) => {
+   dbmethod.insert_tile(instance, (newdocs) => {
    console.log(newdocs)
    })
    //*/
 
 /*
-   dbmethod.get_tiles_cid(target_cid, (docs) => {
+   dbmethod.find_tiles_cid(target_cid, (docs) => {
    console.log(docs)
    })
    //*/
 
 /*
-   dbmethod.get_clip_id(target_cid, (doc) => {
+   dbmethod.find_clip_id(target_cid, (doc) => {
    console.log(doc)
    })
    //*/
 
 /*
-   dbmethod.set_clip(['helloworld', 'coordinote'], (newdocs) => {
+   dbmethod.insert_clip(['helloworld', 'coordinote'], (newdocs) => {
    console.log(newdocs)
    })
    //*/
@@ -97,7 +98,7 @@ dbmethod.update_tilecon_cidid(con, target_cid, target_id, (doc) => {
    "sty": "txt",
    "con": '$y = ax => x = \frac{y}{a}$'
    }
-   dbmethod.set_tile(instance, (newdocs) => {
+   dbmethod.insert_tile(instance, (newdocs) => {
    console.log(newdocs)
    })
    //*/

--- a/nedb_module/test/nedb_test.js
+++ b/nedb_module/test/nedb_test.js
@@ -36,7 +36,7 @@ let target_id = "9SOzR0peDyDw9e80"
    })
    //*/
 
-/*
+//*
 dbmethod.find_clips_tags(['helloworld'], (clips) => {
    console.log(clips)
    })


### PR DESCRIPTION
* `find_clips_tags()` におけるバグ修正
  - `tile` 要素が適切に追加されるよう修正
* 各メソッド名(命名規則)を変更
  - `get` -> `find`
  - `set` -> `insert`
* ファイルロード関数化
  - `dbLoad()`: タイル用コレクションを必要に応じてインスタンス生成する
* 各種バグの種の修正
  - `for-of` を `async.each` or `async.eachSeries`として処理完了を同期処理とする